### PR TITLE
fix: do not include accessId, accessKey, securityToken in provider

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -56,21 +56,6 @@ func Provider() tfbridge.ProviderInfo {
 					EnvVars: []string{"TENCENTCLOUD_REGION"},
 				},
 			},
-			"secret_id": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"TENCENTCLOUD_SECRET_ID"},
-				},
-			},
-			"secret_key": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"TENCENTCLOUD_SECRET_KEY"},
-				},
-			},
-			"security_token": {
-				Default: &tfbridge.DefaultInfo{
-					EnvVars: []string{"TENCENTCLOUD_SECURITY_TOKEN"},
-				},
-			},
 		},
 		Resources:   info.GetResourceInfo(mainPkg),
 		DataSources: info.GetDataSourceInfo(mainPkg),


### PR DESCRIPTION
Credential should not be stored in provider. Because for temporary credential with `security_token`, the saved key is not available in next run if token timeout. Resulting in Pulumi always exit with error
```
Code=AuthFailure.TokenFailure, Message=Token verification failed. Please check your Token is correct.
```
in next  `pulumi refresh` command.

- related: alicloud only have `ecs_role_name`,`region`,`profile` in config 
  https://github.com/pulumi/pulumi-alicloud/blob/master/provider/resources.go#L350-L367